### PR TITLE
Shortening GPG key ID of torproject.org to 16 characters.

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -11,7 +11,7 @@ class tor::apt () {
 
     # Declare apt::key only if installing (to avoid double removal)
     if $ensure == 'present' {
-      apt::key {'A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89':
+      apt::key {'EE8CBC9E886DDD89':
         key_server => 'keys.gnupg.net',
         before     => Apt::Source['tor'],
       }


### PR DESCRIPTION
Module puppet-tor relies on module puppetlabs-apt for managing apt repository for torproject.org. The module now specifies the GPG key of the Tor Project as a 32 character string, while the apt module of Puppetlabs validates key ID's of 8 or 16 characters long only).
