### PR TITLE
Update to be compatable with newer apt module

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -9,18 +9,15 @@ class tor::apt () {
 
     include 'apt'
 
-    # Declare apt::key only if installing (to avoid double removal)
-    if $ensure == 'present' {
-      apt::key {'A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89':
-        key_server => 'keys.gnupg.net',
-        before     => Apt::Source['tor'],
-      }
-    }
     apt::source { 'tor':
-      ensure            => $ensure,
-      location          => 'http://deb.torproject.org/torproject.org',
-      release           => $::lsbdistcodename,
-      repos             => 'main',
+      ensure   => $ensure,
+      location => 'http://deb.torproject.org/torproject.org',
+      release  => $::lsbdistcodename,
+      repos    => 'main',
+      key      => {
+        id     => 'A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89',
+        server => 'keys.gnupg.net',
+      }
     } ->
     package {'deb.torproject.org-keyring': ensure => $ensure}
   }


### PR DESCRIPTION
The puppetlabs/apt module changed to that key_server is no longer a
valid parameter for Apt::Key, but the key can now be defined as part of
Apt::Source.

Original error from Puppet run:
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Apt::Key[A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89]: has no parameter named 'key_server' at /etc/puppetlabs/code/environments/development/modules/tor/manifests/apt.pp:14 on node XXXXXXX
```

Error is not present after modifications. I've not tested which versions of the Apt module this works with, but it does work with 4.4.1 (and should work with all 4.x versions).